### PR TITLE
fix(build): Exclude MaterialDesignThemes runtime assets from publish

### DIFF
--- a/THJPatcher.csproj
+++ b/THJPatcher.csproj
@@ -16,7 +16,7 @@
     <!-- Optimization settings -->
     <Optimize>true</Optimize>
     <TieredCompilation>true</TieredCompilation>
-
+z
     <!-- App metadata -->
     <AssemblyName>THJInstaller</AssemblyName>
     <Product>THJInstaller</Product>
@@ -24,7 +24,9 @@
 </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignThemes" Version="5.2.1" />
+    <PackageReference Include="MaterialDesignThemes" Version="5.2.1">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="Steamworks.NET" Version="20.1.0" />
     <PackageReference Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>


### PR DESCRIPTION
The `dotnet publish` command was including MaterialDesignThemes.Wpf.dll and its dependency Microsoft.Xaml.Behaviors.dll in the output directory. These DLLs were not needed for the patcher's core function and were causing conflicts with later patching operations.

This change adds `<ExcludeAssets>runtime</ExcludeAssets>` to the `MaterialDesignThemes` PackageReference in `THJPatcher.csproj`. This prevents the unnecessary runtime DLLs from being copied during the publish step, resolving the conflict.